### PR TITLE
Gma 1 incorrect plans

### DIFF
--- a/services/agent_service/src/prompts/prompts.py
+++ b/services/agent_service/src/prompts/prompts.py
@@ -37,7 +37,7 @@ FEEDBACK:
 3. **Assign a source** to each sub-query based on the following rules and examples:
 
    - `"knowledgebase"`:
-     - Use for technical concepts or implementation approaches involving:
+     - Use for technical concepts, research papers present in the knowledgebase, or implementation approaches involving:
        - Advanced RAG techniques (e.g., document indexing, reranking, context expansion).
        - Embedding models, LLM behavior, and hallucination metrics.
        - General architecture or design methodologies.


### PR DESCRIPTION
**Summary**
Fixes incorrect source assignment in query plans by ensuring that research papers are correctly routed to the knowledgebase (KB) source.
**Changes**
Updated plan generation logic to assign KB as the source for relevant technical and research queries.
**How to Test**
Submit a research paper that is in KB - related query and verify that the plan assigns the source as knowledgebase.