### PR TITLE
GMA-26: Format_EvalAgent_Reasoning

### DIFF
--- a/services/agent_service/src/base_agents/eval_agent.py
+++ b/services/agent_service/src/base_agents/eval_agent.py
@@ -80,17 +80,13 @@ class EvalAgent(RoutedAgent):
         parsed = extract_json_with_brace_counting(content)
         return parsed.get("Evaluations")
 
-    def _compute_score_and_reasoning(self, evaluations: List[dict]) -> tuple[float, str]:
+    def _compute_score_and_reasoning(self, evaluations: List[dict]) -> tuple[float, list]:
         total = len(evaluations)
         yes_count = sum(1 for e in evaluations if e.get("label", "").lower() == "yes")
         score = round(yes_count / total, 2) if total else 0.0
 
-        reasoning_lines = []
-        for e in evaluations:
-            reasoning_lines.append(f"• **Fact**: {e['fact']}\n  - **Label**: {e['label']}\n  - **Reason**: {e['reasoning']}")
-        full_reasoning = "\n".join(reasoning_lines)
-
-        return score, full_reasoning
+        # Return the list of evaluation dicts as reasoning (JSON-friendly)
+        return score, evaluations
 
     @message_handler
     async def evaluate_answer(self, message: Message, ctx: MessageContext) -> Message:

--- a/services/agent_service/src/protocols/schemas.py
+++ b/services/agent_service/src/protocols/schemas.py
@@ -35,7 +35,7 @@ class FactEvaluation(BaseModel):
 
 class EvalAgentOutput(BaseModel):
     score: float = Field(..., description="Final score computed as ratio of 'yes' labels to total facts")
-    reasoning: str = Field(..., description="Combined evaluation report including fact labels and explanations")
+    reasoning: List[dict] = Field(..., description="List of fact evaluation dicts")
     error: Optional[str] = Field(None, description="Error message if evaluation failed")
     llm_usage: Optional[LLMUsage] = Field(None, description="Token usage information for the LLM call")
 


### PR DESCRIPTION
**Summary**
This PR improves the evaluation agent’s API output by making the reasoning field JSON-friendly.

**Changes**

1. Evaluation Agent Output:

- The reasoning field in the evaluation agent’s output is now a list of objects (each with fact, label, and reasoning fields) instead of a markdown-formatted string.
- This matches the structure of the LLM’s fact evaluation output and makes UI rendering much easier.

2. Schema Update:

- The EvalAgentOutput schema has been updated to reflect that reasoning is now a List[dict] rather than a string.