### PR TITLE
KB-Agent updates and time-out increased

### DIFF
--- a/services/agent_service/src/base_agents/executor_agent.py
+++ b/services/agent_service/src/base_agents/executor_agent.py
@@ -464,7 +464,7 @@ class ExecutorAgent(RoutedAgent):
                         messages=[{"role": "user", "content": prompt}],
                         model=self.model
                     ),
-                    timeout=60  # 1 minute timeout for LLM call
+                    timeout=300  # 1 minute timeout for LLM call
                 )
             except asyncio.TimeoutError:
                 logger.error("LLM aggregation request timed out, using fallback")

--- a/services/agent_service/src/base_agents/manager/manager_utils.py
+++ b/services/agent_service/src/base_agents/manager/manager_utils.py
@@ -165,7 +165,7 @@ async def run_evaluation_loop(
         # Threshold met → stop looping, no edit needed
         if score >= EVALUATION_PASS_THRESHOLD:
             logger.info("[EvaluationAgent] Score ≥ threshold, skipping edits.")
-            break
+            return current_answer, eval_history, editor_history
 
         # ── Edit ───────────────────────────────────────────────────────────────
         new_answer, editor_log = await run_editor_pass(

--- a/services/agent_service/src/onboarding_team/team.py
+++ b/services/agent_service/src/onboarding_team/team.py
@@ -196,7 +196,7 @@ async def send_to_agent(user_message: Message) -> str:
         try:
             response = await asyncio.wait_for(
                 RUNTIME.send_message(user_message, MANAGER_AGENT_ID),
-                timeout=300  # 5 minutes timeout
+                timeout=600  # 5 minutes timeout
             )
             return response.content
         except asyncio.TimeoutError as e:

--- a/services/agent_service/src/prompts/multihop_prompts.py
+++ b/services/agent_service/src/prompts/multihop_prompts.py
@@ -60,6 +60,7 @@ You are a scientific assistant. Given the following retrieved passages, write a 
 - Before summarizing, review the metadata fields (section, metrics_mentioned, chunk_type, gen_ai_keywords, entities) for each passage to assess its relevance to the main question.
 - Only include information from passages that are highly relevant to the main question. Ignore any passage whose content and metadata indicates low relevance.
 - Filter out irrelevant chunks and focus your summary only on the most relevant evidence.
+- Do NOT include any <think>...</think> tags or any internal chain-of-thought, scratchpad, or "thinking" content. Output only the final concise summary.
 - If any tables or numeric results appear, naturally include them in your answer, reproducing them verbatim in markdown table format or as inline numbers.
 - If there are no numeric results or tables, simply provide the most complete qualitative synthesis possible, referencing any comparative or descriptive evidence.
 - Do **not** mention missing numbers or tables, and do **not** include any section headers about numeric results.
@@ -85,10 +86,11 @@ You are a scientific assistant. Given the following retrieved passages, answer t
 - Before summarizing, review the metadata fields (section, metrics_mentioned, chunk_type, gen_ai_keywords, entities) for each passage to assess its relevance to the main question.
 - Only include information from passages that are highly relevant to the main question. Ignore any passage whose metadata indicates low relevance.
 - Filter out irrelevant chunks and focus your summary only on the most relevant evidence.
-- If any tables or numeric results appear, naturally include them in your answer, reproducing them verbatim in markdown table format or as inline numbers.
-- If there are no numeric results or tables, simply provide the most complete qualitative synthesis possible, referencing any comparative or descriptive evidence.
-- Do **not** mention missing numbers or tables, and do **not** include any section headers about numeric results.
-- Your summary should be brief,clear, direct, and reference all relevant evidence from the passages.
+ - Do NOT include any <think>...</think> tags or any internal chain-of-thought, scratchpad, or "thinking" content. Output only the final concise answer to the sub-question.
+ - If any tables or numeric results appear, naturally include them in your answer, reproducing them verbatim in markdown table format or as inline numbers.
+ - If there are no numeric results or tables, simply provide the most complete qualitative synthesis possible, referencing any comparative or descriptive evidence.
+ - Do **not** mention missing numbers or tables, and do **not** include any section headers about numeric results.
+ - Your summary should be brief,clear, direct, and reference all relevant evidence from the passages.
 
 
 

--- a/services/agent_service/src/source_agents/knowledgebase_agent.py
+++ b/services/agent_service/src/source_agents/knowledgebase_agent.py
@@ -84,6 +84,18 @@ def parse_reasoner_json(text: str) -> dict:
         return {}
 
 
+def strip_think_tags(text: str) -> str:
+    """
+    Remove any <think>...</think> tags (and their contents) from LLM outputs.
+    Uses a regex to strip tags case-insensitively and across newlines.
+    """
+    if not text:
+        return text
+    # Remove any <think ...>...</think> blocks
+    cleaned = re.sub(r'<think\b[^>]*>.*?</think>', '', text, flags=re.S | re.I)
+    return cleaned.strip()
+
+
 class KBAgent(RoutedAgent):
     def __init__(self, persist_directory: str = None):
         super().__init__("knowledgebase_agent")
@@ -169,7 +181,7 @@ class KBAgent(RoutedAgent):
             cumulative_output_tokens += getattr(usage, "output_tokens", 0)
         except Exception:
             pass
-        global_summary = global_summary_response.choices[0].message.content
+        global_summary = strip_think_tags(global_summary_response.choices[0].message.content)
         logger.info(f"[Hop 1] Global summary: {global_summary}")
 
         local_summary_prompt = LOCAL_SUMMARIZER_PROMPT.format(
@@ -187,7 +199,7 @@ class KBAgent(RoutedAgent):
             cumulative_output_tokens += getattr(usage, "output_tokens", 0)
         except Exception:
             pass
-        local_summary = local_summary_response.choices[0].message.content
+        local_summary = strip_think_tags(local_summary_response.choices[0].message.content)
         logger.info(
             f"[Hop 1] Local summary for '{main_question}': {local_summary}")
 
@@ -226,7 +238,7 @@ class KBAgent(RoutedAgent):
             cumulative_output_tokens += getattr(usage, "output_tokens", 0)
         except Exception:
             pass
-        reasoner_raw = reasoner_response.choices[0].message.content
+        reasoner_raw = strip_think_tags(reasoner_response.choices[0].message.content)
         logger.info(f"[Hop 1] Reasoner raw: {reasoner_raw}")
         reasoner = parse_reasoner_json(reasoner_raw)
         hop_info["reasoner_output"] = reasoner
@@ -316,7 +328,7 @@ class KBAgent(RoutedAgent):
                     cumulative_output_tokens += getattr(usage, "output_tokens", 0)
                 except Exception:
                     pass
-                global_summary = global_summary_response.choices[0].message.content
+                global_summary = strip_think_tags(global_summary_response.choices[0].message.content)
                 logger.info(f"[Hop {hop}] Global summary: {global_summary}")
 
                 local_summary_prompt = LOCAL_SUMMARIZER_PROMPT.format(
@@ -335,7 +347,7 @@ class KBAgent(RoutedAgent):
                     cumulative_output_tokens += getattr(usage, "output_tokens", 0)
                 except Exception:
                     pass
-                local_summary = local_summary_response.choices[0].message.content
+                local_summary = strip_think_tags(local_summary_response.choices[0].message.content)
                 logger.info(
                     f"[Hop {hop}] Local summary for '{query_text}': {local_summary}")
 
@@ -379,7 +391,7 @@ class KBAgent(RoutedAgent):
                 cumulative_output_tokens += getattr(usage, "output_tokens", 0)
             except Exception:
                 pass
-            reasoner_raw = reasoner_response.choices[0].message.content
+            reasoner_raw = strip_think_tags(reasoner_response.choices[0].message.content)
             logger.info(f"[Hop {hop}] Reasoner raw: {reasoner_raw}")
             reasoner = parse_reasoner_json(reasoner_raw)
 
@@ -435,7 +447,7 @@ class KBAgent(RoutedAgent):
             cumulative_output_tokens += getattr(usage, "output_tokens", 0)
         except Exception:
             pass
-        answer = answer_response.choices[0].message.content
+        answer = strip_think_tags(answer_response.choices[0].message.content)
 
         hops_trace.append({
             "hop": "final",


### PR DESCRIPTION
**Changes**

* Added a function to remove <think></think> tags from llm response in KB Agent.
* Increased time-out amount to a large number to at-least guarantee response by the application.
* Made a small fix in eval_agent logic to further reduce the chances of accidental re-evaluation after threshold score has been reached.